### PR TITLE
Add cop for Spree.t method calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-solidus (0.1.1)
+    rubocop-solidus (0.1.2)
       rubocop
 
 GEM

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,3 +2,8 @@ Solidus/ClassEvalDecorator:
   Description: 'Checks if Class.class_eval is being used in the code'
   Enabled: true
   VersionAdded: '0.1.1'
+
+Solidus/SpreeTDecprecated:
+  Description: 'Checks if Spree.t is being used and replaces it with I18n.t.'
+  Enabled: true
+  VersionAdded: '0.1.2'

--- a/lib/rubocop/cop/solidus/spree_t_decprecated.rb
+++ b/lib/rubocop/cop/solidus/spree_t_decprecated.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Solidus
+      # This cop finds Spree.t method calls and replaces them with the I18n,t method call
+      # This cop is needed as the Spree.t version has been deprecated in future version.
+      #
+      #
+      # @example EnforcedStyle: bar (default)
+      #   # bad
+      #   Spree.t(:bar)
+      #
+      #   # good
+      #   I18n.t(:bar)
+      #
+      #   # good
+      #   good_bar_method(args)
+      #
+      class SpreeTDecprecated < Base
+        extend AutoCorrector
+        MSG = 'Use I18n.t instead of Spree.t which has been deprecated in future versions.'
+
+        RESTRICT_ON_SEND = %i[t].freeze
+
+        # @!method spree_t?(node)
+        def_node_matcher :spree_t?, <<~PATTERN
+          (send ($...) :t ...)
+        PATTERN
+
+        def on_send(node)
+          return unless spree_t?(node)
+
+          return unless spree_t?(node).include?(:Spree)
+
+          add_offense(node) do |corrector|
+            corrector.replace(node, "I18n.t('#{node.first_argument.source.to_s.gsub(':', '')}', scope: 'spree')")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/solidus_cops.rb
+++ b/lib/rubocop/cop/solidus_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "solidus/class_eval_decorator"
+require_relative 'solidus/spree_t_decprecated'

--- a/lib/rubocop/solidus/version.rb
+++ b/lib/rubocop/solidus/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Solidus
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/rubocop/cop/solidus/spree_t_decprecated_spec.rb
+++ b/spec/rubocop/cop/solidus/spree_t_decprecated_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Solidus::SpreeTDecprecated, :config do
+  let(:config) { RuboCop::Config.new("Solidus/SpreeTDecprecated" => { "Enabled" => true }) }
+
+  it 'registers an offense when using `#bad_method`' do
+    expect_offense(<<~RUBY)
+      Spree.t(:solidus_store)
+      ^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      I18n.t('solidus_store', scope: 'spree')
+    RUBY
+  end
+
+  it 'registers an offense when using `#bad_method` in a statement' do
+    expect_offense(<<~RUBY)
+      var = Spree.t(:solidus_store)
+            ^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      var = I18n.t('solidus_store', scope: 'spree')
+    RUBY
+  end
+
+  it 'does not register an offense when using `#good_method`' do
+    expect_no_offenses(<<~RUBY)
+      I18n.t(:solidus_store)
+    RUBY
+  end
+end


### PR DESCRIPTION
This PR adds a new cop `Solidus/SpreeTDeprecated`

The new cop checks for `Spree.t` method calls and replaces them with `I18n.t` method call
