### PR TITLE
Add cop for Spree.t calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
 
 DEPENDENCIES
   pry

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-solidus (0.1.1)
+    rubocop-solidus (0.1.2)
       rubocop
 
 GEM

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,3 +2,8 @@ Solidus/ClassEvalDecorator:
   Description: 'Checks if Class.class_eval is being used in the code'
   Enabled: true
   VersionAdded: '0.1.1'
+
+Solidus/SpreeTDecprecated:
+  Description: 'Checks if Spree.t is being used and replaces it with I18n.t.'
+  Enabled: true
+  VersionAdded: '0.1.2'

--- a/lib/rubocop/cop/solidus/spree_t_decprecated.rb
+++ b/lib/rubocop/cop/solidus/spree_t_decprecated.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Solidus
+      # This cop finds Spree.t method calls and replaces them with the I18n,t method call
+      # This cop is needed as the Spree.t version has been deprecated in future version.
+      #
+      #
+      # @example EnforcedStyle: bar (default)
+      #   # bad
+      #   Spree.t(:bar)
+      #
+      #   # good
+      #   I18n.t(:bar, scope: :spree)
+      #
+      #   # bad
+      #   Spree.t(:bar, scope: [:city])
+      #
+      #   # good
+      #   I18n.t(:bar, scope: [:spree, :city])
+      #
+      #   # bad
+      #   Spree.t(:bar, scope: [:city], email: email)
+      #
+      #   # good
+      #   I18n.t(:bar, scope: [:spree, :city], email: email)
+      #
+      #   # bad
+      #   Spree.t('bar', scope: 'admin.city')
+      #
+      #   # good
+      #   I18n.t('bar', scope: 'spree.admin.city')
+      #
+      #
+      class SpreeTDecprecated < Base
+        extend AutoCorrector
+        MSG = 'Use I18n.t instead of Spree.t which has been deprecated in future versions.'
+
+        RESTRICT_ON_SEND = %i[t].freeze
+
+        # @!method spree_t?(node)
+        def_node_matcher :spree_t?, <<~PATTERN
+          (send ($...) :t ...)
+        PATTERN
+
+        def on_send(node)
+          return unless spree_t?(node)
+
+          return unless spree_t?(node).include?(:Spree)
+
+          add_offense(node) do |corrector|
+            corrector.replace(node, corrected_statement(node))
+          end
+        end
+
+        def corrected_statement(node)
+          arguments = node.arguments
+
+          new_statement = 'I18n.t('
+          new_statement += arguments.first.source
+          new_statement += ', scope: :spree' if scope_missing?(arguments)
+
+          node.arguments.drop(1).each do |argument|
+            if argument.source.include? 'scope:'
+              new_argument = add_spree_scope(argument)
+              new_statement += ", #{new_argument}"
+            else
+              new_statement += ", #{argument.source}"
+            end
+          end
+          new_statement += ')'
+          new_statement
+        end
+
+        def scope_missing?(arguments)
+          arguments.each do |argument|
+            return false if argument.source.include? 'scope:'
+          end
+          true
+        end
+
+        def add_spree_scope(argument)
+          modified_argument = ''
+
+          argument.each_pair do |key, value|
+            if key.source == 'scope'
+              modified_argument = if value.type == :array
+                                    "#{key.source}: #{value.source.gsub('[', '[:spree, ')}"
+                                  else
+                                    "#{key.source}: 'spree.#{value.source.gsub("'", '')}'"
+                                  end
+            else
+              modified_argument += ", #{key.source}: #{value.source}"
+            end
+          end
+
+          modified_argument
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/solidus_cops.rb
+++ b/lib/rubocop/cop/solidus_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "solidus/class_eval_decorator"
+require_relative 'solidus/spree_t_decprecated'

--- a/lib/rubocop/solidus/version.rb
+++ b/lib/rubocop/solidus/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Solidus
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/spec/rubocop/cop/solidus/spree_t_decprecated_spec.rb
+++ b/spec/rubocop/cop/solidus/spree_t_decprecated_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Solidus::SpreeTDecprecated, :config do
+  let(:config) { RuboCop::Config.new('Solidus/SpreeTDecprecated' => { 'Enabled' => true }) }
+
+  describe 'first argument is a symbol' do
+    it 'registers an offense when using `#bad_method`' do
+      expect_offense(<<~RUBY)
+        Spree.t(:solidus_store)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t(:solidus_store, scope: :spree)
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` with custom scope' do
+      expect_offense(<<~RUBY)
+        Spree.t(:solidus_store, scope: [:custom_scope])
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t(:solidus_store, scope: [:spree, :custom_scope])
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` with custom scope and custom arguments' do
+      expect_offense(<<~RUBY)
+        Spree.t(:solidus_store, scope: [:custom_scope], email: params[:email])
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t(:solidus_store, scope: [:spree, :custom_scope], email: params[:email])
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` in a statement' do
+      expect_offense(<<~RUBY)
+        var = Spree.t(:solidus_store)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = I18n.t(:solidus_store, scope: :spree)
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` with a string scope' do
+      expect_offense(<<~RUBY)
+        Spree.t(:solidus_store, scope: 'admin.compositions')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t(:solidus_store, scope: 'spree.admin.compositions')
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` without scope argument and with other arguments' do
+      expect_offense(<<~RUBY)
+        Spree.t(:solidus_store, address_button: address_button).html_safe
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t(:solidus_store, scope: :spree, address_button: address_button).html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `#good_method` with string for scope' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t(:solidus_store, scope: 'spree')
+      RUBY
+    end
+
+    it 'does not register an offense when using `#good_method`' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t(:solidus_store, scope: :spree)
+      RUBY
+    end
+
+    it 'does not register an offense when using `#good_method` with custom scope' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t(:solidus_store, scope: [:custom_scope])
+      RUBY
+    end
+
+    it 'does not register an offense when using `#good_method` with custom scope and custom arguments' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t(:solidus_store, scope: [:custom_scope], email: params[:email])
+      RUBY
+    end
+  end
+
+  describe 'first argument is a string' do
+    it 'registers an offense when using `#bad_method`' do
+      expect_offense(<<~RUBY)
+        Spree.t('solidus_store')
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t('solidus_store', scope: :spree)
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` with custom scope' do
+      expect_offense(<<~RUBY)
+        Spree.t('solidus_store', scope: [:custom_scope])
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t('solidus_store', scope: [:spree, :custom_scope])
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` with custom scope and custom arguments' do
+      expect_offense(<<~RUBY)
+        Spree.t('solidus_store', scope: [:custom_scope], email: params[:email])
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t('solidus_store', scope: [:spree, :custom_scope], email: params[:email])
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` in a statement' do
+      expect_offense(<<~RUBY)
+        var = Spree.t('solidus_store')
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        var = I18n.t('solidus_store', scope: :spree)
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` with a string scope' do
+      expect_offense(<<~RUBY)
+        Spree.t('solidus_store', scope: 'admin.compositions')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t('solidus_store', scope: 'spree.admin.compositions')
+      RUBY
+    end
+
+    it 'registers an offense when using `#bad_method` without scope argument and with other arguments' do
+      expect_offense(<<~RUBY)
+        Spree.t('solidus_store', address_button: address_button).html_safe
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use I18n.t instead of Spree.t which has been deprecated in future versions.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        I18n.t('solidus_store', scope: :spree, address_button: address_button).html_safe
+      RUBY
+    end
+
+    it 'does not register an offense when using `#good_method`' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t('solidus_store', scope: :spree)
+      RUBY
+    end
+
+    it 'does not register an offense when using `#good_method` with string for scope' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t('solidus_store', scope: 'spree')
+      RUBY
+    end
+
+    it 'does not register an offense when using `#good_method` with custom scope' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t('solidus_store', scope: [:custom_scope])
+      RUBY
+    end
+
+    it 'does not register an offense when using `#good_method` with custom scope and custom arguments' do
+      expect_no_offenses(<<~RUBY)
+        I18n.t('solidus_store', scope: [:custom_scope], email: params[:email])
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new cop `Solidus/SpreeTDeprecated`

The new cop checks for `Spree.t` method calls and replaces them with `I18n.t` method call