### PR TITLE
Create module to specify Solidus version for a cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,13 @@
+AllCops:
+  # What version of Solidus is the inspected code using? If a value is specified
+  # for TargetSolidusVersion then it is used. Acceptable values are specified
+  # as a float (i.e. 3.1); the patch version of Solidus should not be included.
+  # If TargetSolidusVersion is not set, RuboCop will parse the Gemfile.lock or
+  # gems.locked file to find the version of Solidus that has been bound to the
+  # application.  If neither of those files exist, RuboCop will use Solidus 3.0
+  # as the default.
+  TargetSolidusVersion: ~
+
 Solidus/ClassEvalDecorator:
   Description: 'Checks if Class.class_eval is being used in the code'
   Enabled: true

--- a/lib/rubocop/cop/mixin/target_solidus_version.rb
+++ b/lib/rubocop/cop/mixin/target_solidus_version.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # This module provides a way to specify a minimum Solidus version for a cop.
+    # It also provides a way to check if the current Solidus version is affected.
+    # The minimum Solidus version can be specified in the cop itself in this way:
+    #   include TargetSolidusVersion
+    #   minimum_solidus_version 2.11
+    module TargetSolidusVersion
+      DEFAULT_SOLIDUS_VERSION = 3.0
+
+      def self.included(target)
+        target.extend(ClassMethods)
+      end
+
+      # These class methods are automatically added to the cop when the module
+      # is included. They are used to specify the minimum Solidus version for the cop.
+      module ClassMethods
+        def minimum_solidus_version(version)
+          @minimum_solidus_version = version
+        end
+
+        def targeted_solidus_version?(version)
+          @minimum_solidus_version <= version
+        end
+      end
+
+      def affected_solidus_version?
+        self.class.targeted_solidus_version?(target_solidus_version)
+      end
+
+      def target_solidus_version
+        @target_solidus_version ||=
+          if config.for_all_cops['TargetSolidusVersion']
+            config.for_all_cops['TargetSolidusVersion'].to_f
+          elsif target_solidus_version_from_bundler_lock_file
+            target_solidus_version_from_bundler_lock_file
+          else
+            DEFAULT_SOLIDUS_VERSION
+          end
+      end
+
+      def target_solidus_version_from_bundler_lock_file
+        @target_solidus_version_from_bundler_lock_file ||= read_solidus_version_from_bundler_lock_file
+      end
+
+      def read_solidus_version_from_bundler_lock_file
+        lock_file_path = config.bundler_lock_file_path
+        return nil unless lock_file_path
+
+        File.foreach(lock_file_path) do |line|
+          # If Solidus (or one of its frameworks) is in Gemfile.lock, there should be a line like:
+          #   solidus_core (X.X.X)
+          result = line.match(/^\s+solidus_core\s+\((\d+\.\d+)/)
+          return result.captures.first.to_f if result
+        end
+      end
+
+      # This method overrides the one in RuboCop::Cop::Base.
+      # Since this method is called for every offense, we can use it to check
+      # if the Solidus version is affected and skip the offense if it's not.
+      def add_offense(node_or_range, message: nil, severity: nil, &block)
+        return unless affected_solidus_version?
+
+        super
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/solidus_cops.rb
+++ b/lib/rubocop/cop/solidus_cops.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'mixin/target_solidus_version'
+
 require_relative 'solidus/class_eval_decorator'
 require_relative 'solidus/reimbursement_hook_deprecated'
 require_relative 'solidus/spree_calculator_free_shipping_deprecated'

--- a/spec/rubocop/mixin/target_solidus_version_spec.rb
+++ b/spec/rubocop/mixin/target_solidus_version_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::TargetSolidusVersion do
+  include FileHelper
+
+  let(:base_cop) { RuboCop::Cop::BaseCop }
+  let(:dummy_cop) { base_cop.include(RuboCop::Cop::TargetSolidusVersion).new }
+
+  before do
+    stub_const('RuboCop::Cop::BaseCop', Class.new(RuboCop::Cop::Base))
+  end
+
+  describe '#target_solidus_version' do
+    context 'when TargetSolidusVersion is set' do
+      let(:hash) { { 'TargetSolidusVersion' => solidus_version } }
+
+      before do
+        allow(dummy_cop.config).to receive(:for_all_cops).and_return(hash)
+      end
+
+      context 'with patch version' do
+        let(:solidus_version) { '2.11.5' }
+        let(:solidus_version_to_f) { 2.11 }
+
+        it 'truncates the patch part and converts to a float' do
+          expect(dummy_cop.target_solidus_version).to eq solidus_version_to_f
+        end
+      end
+
+      context 'correctly' do
+        let(:solidus_version) { '2.11' }
+        let(:solidus_version_to_f) { 2.11 }
+
+        it 'uses TargetSolidusVersion' do
+          expect(dummy_cop.target_solidus_version).to eq solidus_version_to_f
+        end
+      end
+    end
+
+    context 'when TargetSolidusVersion is not set', :isolated_environment do
+      context 'and lock files do not exist' do
+        it 'uses the default Solidus version' do
+          default = described_class::DEFAULT_SOLIDUS_VERSION
+          expect(dummy_cop.target_solidus_version).to eq default
+        end
+      end
+
+      context 'and Gemfile.lock exists' do
+        let(:base_path) { dummy_cop.config.base_dir_for_path_parameters }
+        let(:lock_file_path) { File.join(base_path, 'Gemfile.lock') }
+
+        before do
+          allow(dummy_cop.config).to receive(:bundler_lock_file_path).and_return(lock_file_path)
+        end
+
+        it 'uses the Solidus version in Gemfile.lock' do
+          content =
+            <<~LOCKFILE
+              GEM
+                remote: https://rubygems.org/
+                specs:
+                  solidus (3.1.9)
+                    solidus_api (= 3.1.9)
+                    solidus_backend (= 3.1.9)
+                    solidus_core (= 3.1.9)
+                    solidus_frontend (= 3.1.9)
+                    solidus_sample (= 3.1.9)
+                  solidus_core (3.1.9)
+
+              PLATFORMS
+                ruby
+
+              DEPENDENCIES
+                solidus (~> 3.1.0)
+
+              BUNDLED WITH
+                2.3.22
+            LOCKFILE
+          create_file(lock_file_path, content)
+          expect(dummy_cop.target_solidus_version).to eq 3.1
+        end
+
+        it 'uses the default Solidus when Solidus is not in Gemfile.lock' do
+          content =
+            <<~LOCKFILE
+              GEM
+                remote: https://rubygems.org/
+                specs:
+                  bump (0.5.4)
+
+              PLATFORMS
+                ruby
+
+              DEPENDENCIES
+                bump
+
+              BUNDLED WITH
+                2.3.22
+            LOCKFILE
+          create_file(lock_file_path, content)
+          default = described_class::DEFAULT_SOLIDUS_VERSION
+          expect(dummy_cop.target_solidus_version).to eq default
+        end
+      end
+    end
+  end
+
+  describe '#affected_solidus_version?' do
+    context 'when target_solidus_version is lower than minimum_solidus_version' do
+      it 'returns false' do
+        dummy_cop.class.minimum_solidus_version 3.1
+        expect(dummy_cop.affected_solidus_version?).to be false
+      end
+    end
+
+    context 'when target_solidus_version is greater than minimum_solidus_version' do
+      it 'returns true' do
+        dummy_cop.class.minimum_solidus_version 2.11
+        expect(dummy_cop.affected_solidus_version?).to be true
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'rubocop-solidus'
 require 'rubocop/rspec/support'
 require 'pry'
+require_relative 'support/file_helper'
 
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module FileHelper
+  def create_file(file_path, content)
+    file_path = File.expand_path(file_path)
+    create_dir file_path
+
+    File.open(file_path, 'w') do |file|
+      case content
+      when String
+        file.puts content
+      when Array
+        file.puts content.join("\n")
+      end
+    end
+  end
+
+  def create_dir(file_path)
+    dir_path = File.dirname(file_path)
+    FileUtils.makedirs dir_path unless File.exist?(dir_path)
+  end
+end


### PR DESCRIPTION
Some cops are only applicable to some versions of Solidus.

This PR introduces a new module to use for all cops that need this feature.

The minimum Solidus version can be specified in the cop itself in this way:
```ruby
include TargetSolidusVersion
minimum_solidus_version 2.11
```