### PR TITLE
Add limitation to reimbursement hook

### DIFF
--- a/lib/rubocop/cop/solidus/reimbursement_hook_deprecated.rb
+++ b/lib/rubocop/cop/solidus/reimbursement_hook_deprecated.rb
@@ -4,6 +4,9 @@ module RuboCop
   module Cop
     module Solidus
       class ReimbursementHookDeprecated < Base
+        include TargetSolidusVersion
+        minimum_solidus_version 2.11
+
         MSG = 'Please remove reimbursement_success_hooks and reimbursement_failed_hooks. Subscribe to reimbursement_reimbursed event instead.'
 
         def_node_matcher :success_hook?, <<~PATTERN


### PR DESCRIPTION
Add minimum Solidus version limitation to the reimbursement hook because the deprecation is introduced starting from Solidus 2.11.

Closes #27.