### PR TITLE
Fix gem version comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## master (unreleased)
 
+### New features
+
+* [#45](https://github.com/nebulab/rubocop-solidus/pull/45): Fix gem version comparison. ([@MassimilianoLattanzio][])
+
 ## 0.1.0 (2023-07-10)
 
 - Initial release
+[@MassimilianoLattanzio]: https://github.com/MassimilianoLattanzio

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-solidus (0.1.1)
+    rubocop-solidus (0.1.2)
       rubocop
 
 GEM

--- a/lib/rubocop/cop/mixin/target_solidus_version.rb
+++ b/lib/rubocop/cop/mixin/target_solidus_version.rb
@@ -22,7 +22,7 @@ module RuboCop
         end
 
         def targeted_solidus_version?(version)
-          @minimum_solidus_version <= version
+          Gem::Version.new(@minimum_solidus_version) <= Gem::Version.new(version)
         end
       end
 
@@ -47,7 +47,7 @@ module RuboCop
 
       def target_solidus_version
         @target_solidus_version ||=
-          config.for_all_cops['TargetSolidusVersion']&.to_f || solidus_version_from_lock_file || DEFAULT_SOLIDUS_VERSION
+          config.for_all_cops['TargetSolidusVersion'] || solidus_version_from_lock_file || DEFAULT_SOLIDUS_VERSION
       end
 
       def solidus_version_from_lock_file
@@ -62,7 +62,7 @@ module RuboCop
           # If Solidus (or one of its frameworks) is in Gemfile.lock, there should be a line like:
           #   solidus_core (X.X.X)
           result = line.match(/^\s+solidus_core\s+\((\d+\.\d+)/)
-          return result.captures.first.to_f if result
+          return result.captures.first if result
         end
       end
     end

--- a/lib/rubocop/solidus/version.rb
+++ b/lib/rubocop/solidus/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Solidus
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end

--- a/relnotes/v0.1.2.md
+++ b/relnotes/v0.1.2.md
@@ -1,12 +1,5 @@
-## master (unreleased)
-
-## 0.1.2 (2023-07-14)
-
 ### New features
 
 * [#45](https://github.com/nebulab/rubocop-solidus/pull/45): Fix gem version comparison. ([@MassimilianoLattanzio][])
 
-## 0.1.0 (2023-07-10)
-
-- Initial release
 [@MassimilianoLattanzio]: https://github.com/MassimilianoLattanzio

--- a/spec/rubocop/mixin/target_solidus_version_spec.rb
+++ b/spec/rubocop/mixin/target_solidus_version_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::TargetSolidusVersion do
       end
 
       context 'and TargetSolidusVersion is bigger than minimum_solidus_version' do
-        let(:solidus_version) { '2.6' }
+        let(:solidus_version) { '2.10' }
 
         it_behaves_like 'affected solidus version'
       end
@@ -117,19 +117,19 @@ RSpec.describe RuboCop::Cop::TargetSolidusVersion do
               GEM
                 remote: https://rubygems.org/
                 specs:
-                  solidus (3.4.3)
-                    solidus_api (= 3.4.3)
-                    solidus_backend (= 3.4.3)
-                    solidus_core (= 3.4.3)
-                    solidus_frontend (= 3.4.3)
-                    solidus_sample (= 3.4.3)
-                  solidus_core (3.4.3)
+                  solidus (3.10.3)
+                    solidus_api (= 3.10.3)
+                    solidus_backend (= 3.10.3)
+                    solidus_core (= 3.10.3)
+                    solidus_frontend (= 3.10.3)
+                    solidus_sample (= 3.10.3)
+                  solidus_core (3.10.3)
 
               PLATFORMS
                 ruby
 
               DEPENDENCIES
-                solidus (~> 3.4.0)
+                solidus (~> 3.10.0)
 
               BUNDLED WITH
                 2.3.22


### PR DESCRIPTION
Previously, we transformed the gem version to a float because we wanted to compare numbers.

That was causing an issue with 0-ending strings.
For example, `"2.10".to_f` will be transformed into `2.1` float number.

This PR solves the issue comparing Gem::Version.