### PR TITLE
Fix typos in README and add instructions on how to use the changelog rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A RuboCop extension focused on enforcing Solidus best practices and coding conve
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rubocop-solidus', github: 'nebulab/rubocop-solidus', require: false
+gem 'rubocop-solidus' require: false
 ```
 
 And then execute:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,34 @@ $ bundle exec rake 'new_cop[Solidus/NameOfTheCop]'
 
 and then follow the instructions on the screen.
 
+## Creating changelog entries
+
+Changelog entries are just files under the `changelog/` folder that will be merged
+into `CHANGELOG.md` at release time. You can create new changelog entries like this:
+
+```console
+$ bundle exec rake changelog:new|fix|change
+```
+
+The type of the changelog correspond to "new feature", "bug-fix" and "changed" entries in the changelog.
+
+### Changelog entry format
+
+Here are a few examples:
+
+```markdown
+* [#47](https://github.com/nebulab/rubocop-solidus/issues/46): **(Breaking)** Remove support for old Ruby versions. ([@MassimilianoLattanzio][])
+* [#4](https://github.com/nebulab/rubocop-solidus/pull/4): Update CHANGELOG. ([@piyushswain][])
+```
+
+* Create one file `changelog/{type}_{some_description}.md`, where `type` is `new` (New feature), `fix` or `change`, and `some_description` is unique to avoid conflicts. Task `changelog:fix` (or `:new` or `:change`) can help you.
+* Mark it up in [Markdown syntax][1].
+* The entry should be a single line, starting with `* ` (an asterisk and a space).
+* If the change has a related GitHub issue (e.g. a bug fix for a reported issue), put a link to the issue as `[#123](https://github.com/nebulab/rubocop-solidus/issues/123): `.
+* Describe the brief of the change. The sentence should end with a punctuation.
+* If this is a breaking change, mark it with `**(Breaking)**`.
+* At the end of the entry, add an implicit link to your GitHub user page as `([@username][])`.
+
 ## Release a new version
 
 To release a new version, run the following command:
@@ -68,3 +96,5 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/nebula
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+[1]: https://www.markdownguide.org/basic-syntax/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ After this simply use the `rubocop` command to start linting.
 To create a new cop, run the following command:
 
 ```bash
-$ bundle exec rake new_cop[Solidus/NameOfTheCop]
+$ bundle exec rake 'new_cop[Solidus/NameOfTheCop]'
 ```
 
 and then follow the instructions on the screen.
@@ -45,7 +45,7 @@ and then follow the instructions on the screen.
 To release a new version, run the following command:
 
 ```bash
-$ bundle exec rake cut_release:[major|minor|patch]
+$ bundle exec rake cut_release:major|minor|patch
 ```
 
 and then follow the instructions on the screen.

--- a/changelog/fix_typos_in_readme_and_add_instructions.md
+++ b/changelog/fix_typos_in_readme_and_add_instructions.md
@@ -1,0 +1,1 @@
+* [#48](https://github.com/nebulab/rubocop-solidus/pull/48): Fix typos in README and add instructions on how to use the changelog rake task. ([@MassimilianoLattanzio][])

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -64,8 +64,8 @@ class Changelog
     end
 
     def github_user
-      user = `git config --global credential.username`.chomp
-      warn 'Set your username with `git config --global credential.username "myusernamehere"`' if user.empty?
+      user = `git config --global user.username`.chomp
+      warn 'Set your username with `git config --global user.username "myusernamehere"`' if user.empty?
 
       user
     end


### PR DESCRIPTION
This PR fixes some typos in the README.

Additionally, it adds instructions on how to use the `changelog` rake task and fixes an issue with the git username.